### PR TITLE
Linter comments on method for APSEC annotations missed.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('Test') {
             steps {
                 echo "Building and running tests"
-                sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} clean test"
+                sh "mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} clean test"
             }
         }
         stage('Deploy-Jar') {
@@ -24,7 +24,7 @@ pipeline {
                 }
             }
             steps {
-                sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"
+                sh "mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ pipeline {
         }
         stage('Deploy-Jar') {
             when {
-                branch 'master'
+//                branch 'master'
+                changeRequest target: 'master' // TODO: lakshmi - remove before merge to master
             }
             steps {
                 sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,10 +18,7 @@ pipeline {
         }
         stage('Deploy-Jar') {
             when {
-                anyOf {
-                    branch 'master'
-                    changeRequest target: 'master'
-                }
+                branch 'master'
             }
             steps {
                 sh "mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,7 @@ pipeline {
         }
         stage('Deploy-Jar') {
             when {
-//                branch 'master'
-                changeRequest target: 'master' // TODO: lakshmi - remove before merge to master
+                branch 'master'
             }
             steps {
                 sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stage('Test') {
             steps {
                 echo "Building and running tests"
-                sh "mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} clean test"
+                sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} clean test"
             }
         }
         stage('Deploy-Jar') {
@@ -24,7 +24,7 @@ pipeline {
                 }
             }
             steps {
-                sh "mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"
+                sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,39 @@
+#!/usr/bin/groovy
+pipeline {
+    agent any
+    options {
+        timeout(time: 25, unit: 'MINUTES')
+        timestamps()
+    }
+    environment {
+        MAVEN_OPTS = "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true -DinstallAtEnd=true -DdeployAtEnd=true"
+        MAVEN_CLI_OPTS = "-U -B -e -fae -V"
+    }
+    stages {
+        stage('Test') {
+            steps {
+                echo "Building and running tests"
+                sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} clean test"
+            }
+        }
+        stage('Deploy-Jar') {
+            when {
+                branch 'master'
+            }
+            steps {
+                sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"
+            }
+        }
+    }
+    post {
+        success {
+            slackSend color: 'good', message: "<${env.BUILD_URL}|${currentBuild.fullDisplayName}> ${currentBuild.currentResult}"
+        }
+        failure {
+            slackSend color: 'danger', message: "<${env.BUILD_URL}|${currentBuild.fullDisplayName}> ${currentBuild.currentResult}"
+        }
+        unstable {
+            slackSend color: 'warning', message: "<${env.BUILD_URL}|${currentBuild.fullDisplayName}> ${currentBuild.currentResult}"
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,10 @@ pipeline {
         }
         stage('Deploy-Jar') {
             when {
-                branch 'master'
+                anyOf {
+                    branch 'master'
+                    changeRequest target: 'master'
+                }
             }
             steps {
                 sh "mvn-cd-build mvn -P '!default,repo-proxy' ${MAVEN_CLI_OPTS} deploy -DskipTests"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Inspections provided:
  - **BlockingCallContextReclaimable**: infer blocking calls within `Dispatchers.IO` context which can be migrated to
    non-blocking alternatives
  - **JerseyMethodParameterDefaultValue**: infer if a probable jersey method contains a parameter with a default value
+- **JerseyMainThreadBlockingCall**: infer if a probable jersey resource method contains a main thread blocking call(runblocking)
 
 ## detekt run
 

--- a/README.md
+++ b/README.md
@@ -106,3 +106,13 @@ and if not, throw a "Parameter specified as non-null is null" error on invocatio
 
  - [KT-27947](https://youtrack.jetbrains.com/issue/KT-27947)
  - [KT-28684](https://youtrack.jetbrains.com/issue/KT-28684)
+
+
+## JerseyMainThreadBlockingCall
+
+```yml
+sidekt:
+   JerseyMainThreadBlockingCall:
+    active: true
+    # debug: 'stderr'
+```

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.udaan</groupId>
     <artifactId>sidekt</artifactId>
-    <version>1.0</version>
+    <version>1.16.0</version>
     <packaging>jar</packaging>
 
     <name>com.udaan.sidekt</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.thewisenerd.linters</groupId>
+    <groupId>com.udaan</groupId>
     <artifactId>sidekt</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.github.thewisenerd.linters sidekt</name>
+    <name>com.udaan.sidekt</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <kotlinx.coroutines.version>1.3.8</kotlinx.coroutines.version>
         <junit.version>4.12</junit.version>
         <detekt.version>1.11.0</detekt.version>
+        <versions.udaan-common>[2.0,3.0)</versions.udaan-common>
     </properties>
 
     <dependencies>
@@ -70,6 +71,12 @@
                     <artifactId>spek-dsl-jvm</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.udaan.common</groupId>
+            <artifactId>common-error-trace</artifactId>
+            <version>${versions.udaan-common}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,10 @@
         <version>[2.0,3.0)</version>
     </parent>
 
-    <groupId>com.udaan</groupId>
+    <groupId>com.udaan.detekt</groupId>
     <artifactId>sidekt</artifactId>
-    <version>1.0</version>
+    <!-- version value should be same as <detekt.version> used in <properties> -->
+    <version>1.11.0</version>
     <packaging>jar</packaging>
 
     <name>com.udaan.sidekt</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,9 @@
     </properties>
     <distributionManagement>
         <repository>
-            <id>udaan</id>
-            <url>https://udmvnrepo.blob.core.windows.net/repo</url>
+            <id>artifactory</id>
+            <name>artifactory-releases</name>
+            <url>http://artifactory.dev.udaan.io/artifactory/libs-release-local</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.udaan</groupId>
     <artifactId>sidekt</artifactId>
-    <version>1.16.0</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <name>com.udaan.sidekt</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.udaan</groupId>
     <artifactId>sidekt</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <name>com.udaan.sidekt</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.udaan</groupId>
+        <artifactId>udaan-parent</artifactId>
+        <version>[2.0,3.0)</version>
+    </parent>
+
     <groupId>com.udaan</groupId>
     <artifactId>sidekt</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -18,13 +24,6 @@
         <junit.version>4.12</junit.version>
         <detekt.version>1.11.0</detekt.version>
     </properties>
-    <distributionManagement>
-        <repository>
-            <id>artifactory</id>
-            <name>artifactory-releases</name>
-            <url>http://artifactory.dev.udaan.io/artifactory/libs-release-local</url>
-        </repository>
-    </distributionManagement>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,12 @@
         <junit.version>4.12</junit.version>
         <detekt.version>1.11.0</detekt.version>
     </properties>
+    <distributionManagement>
+        <repository>
+            <id>udaan</id>
+            <url>https://udmvnrepo.blob.core.windows.net/repo</url>
+        </repository>
+    </distributionManagement>
 
     <dependencies>
         <dependency>

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/SideKtRuleSetProvider.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/SideKtRuleSetProvider.kt
@@ -2,6 +2,7 @@ package io.github.thewisenerd.linters.sidekt
 
 import io.github.thewisenerd.linters.sidekt.rules.BlockingCallContext
 import io.github.thewisenerd.linters.sidekt.rules.BlockingCallContextReclaimable
+import io.github.thewisenerd.linters.sidekt.rules.JerseyMainThreadBlockingCall
 import io.github.thewisenerd.linters.sidekt.rules.JerseyMethodParameterDefaultValue
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
@@ -15,7 +16,8 @@ class SideKtRuleSetProvider : RuleSetProvider {
         listOf(
             BlockingCallContext(config),
             BlockingCallContextReclaimable(config),
-            JerseyMethodParameterDefaultValue(config)
+            JerseyMethodParameterDefaultValue(config),
+            JerseyMainThreadBlockingCall(config)
         )
     )
 }

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/SideKtRuleSetProvider.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/SideKtRuleSetProvider.kt
@@ -4,6 +4,7 @@ import io.github.thewisenerd.linters.sidekt.rules.BlockingCallContext
 import io.github.thewisenerd.linters.sidekt.rules.BlockingCallContextReclaimable
 import io.github.thewisenerd.linters.sidekt.rules.JerseyMainThreadBlockingCall
 import io.github.thewisenerd.linters.sidekt.rules.JerseyMethodParameterDefaultValue
+import io.github.thewisenerd.linters.sidekt.rules.ResourceApsecOnboarded
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -17,7 +18,8 @@ class SideKtRuleSetProvider : RuleSetProvider {
             BlockingCallContext(config),
             BlockingCallContextReclaimable(config),
             JerseyMethodParameterDefaultValue(config),
-            JerseyMainThreadBlockingCall(config)
+            JerseyMainThreadBlockingCall(config),
+            ResourceApsecOnboarded(config)
         )
     )
 }

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JerseyMainThreadBlockingCall.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JerseyMainThreadBlockingCall.kt
@@ -1,0 +1,82 @@
+package io.github.thewisenerd.linters.sidekt.rules
+
+import io.github.thewisenerd.linters.sidekt.helpers.Debugger
+import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.psi.*
+
+class JerseyMainThreadBlockingCall(config: Config) : Rule(config)  {
+
+    companion object {
+        const val RUN_BLOCKING_EXP_ID = "runBlocking"
+        val httpMethodList = arrayOf("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS")
+    }
+
+    private val debugStream by lazy {
+        valueOrNull<String>("debug")?.let {
+            Debugger.getOutputStreamForDebugger(it)
+        }
+    }
+
+    override val issue: Issue = Issue(
+        id = JerseyMainThreadBlockingCall::class.java.simpleName,
+        severity = Severity.Performance,
+        description = "main thread blocking call in resource method",
+        debt = Debt.TEN_MINS
+    )
+
+
+    override fun visitNamedFunction(resourceMethod: KtNamedFunction) {
+        super.visitNamedFunction(resourceMethod)
+        val dbg = Debugger.make(JerseyMainThreadBlockingCall::class.java.simpleName, debugStream)
+
+        val hasPathAnnotation = resourceMethod.hasAnnotation("Path")
+        val hasAnyOfHttpMethodAnnotation = resourceMethod.hasAnnotation(*httpMethodList)
+
+        if (!hasPathAnnotation && !hasAnyOfHttpMethodAnnotation) {
+            dbg.i("  hasPathAnnotation=false or none of http method annotation available")
+            return
+        }
+
+        var methodBlockingMainThread = false
+        resourceMethod.children.forEach {
+            if(it is KtCallExpression) {
+                val isUsingRunBlockingExpression = (it.calleeExpression as KtNameReferenceExpression).getReferencedNameAsName().identifier == RUN_BLOCKING_EXP_ID
+                if(isUsingRunBlockingExpression) {
+                    methodBlockingMainThread = true
+                }
+            }
+
+            if(it is KtBlockExpression) {
+                it.children.map { blkExp ->
+                    if(blkExp is KtCallExpression) {
+                        val identifiedBlockingExp = (blkExp.calleeExpression as KtNameReferenceExpression).getReferencedNameAsName().identifier == RUN_BLOCKING_EXP_ID
+                        if(identifiedBlockingExp){
+                            methodBlockingMainThread = true
+                        }
+                    }
+
+                    if(blkExp is KtReturnExpression) {
+                       blkExp.children.filterIsInstance<KtCallExpression>().map { retExp ->
+                           val identifiedBlockingExp = (retExp.calleeExpression as KtNameReferenceExpression).getReferencedNameAsName().identifier == RUN_BLOCKING_EXP_ID
+                           if(identifiedBlockingExp){
+                               methodBlockingMainThread = true
+                           }
+                       }
+                    }
+                }
+            }
+        }
+
+        if(methodBlockingMainThread) {
+            dbg.i("blocks main application thread")
+            report(
+                CodeSmell(
+                    issue = issue,
+                    entity = Entity.from(resourceMethod),
+                    message = "jersey resource method (${resourceMethod.name}) have main thread blocking call)"
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JerseyMainThreadBlockingCall.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JerseyMainThreadBlockingCall.kt
@@ -40,6 +40,15 @@ class JerseyMainThreadBlockingCall(config: Config) : Rule(config)  {
 
         var methodBlockingMainThread = false
         resourceMethod.children.forEach {
+            if(it is KtDotQualifiedExpression) {
+                it.children.filterIsInstance<KtCallExpression>().map { c ->
+                    val isUsingRunBlockingExpression = (c.calleeExpression as KtNameReferenceExpression).getReferencedNameAsName().identifier == RUN_BLOCKING_EXP_ID
+                    if(isUsingRunBlockingExpression) {
+                        methodBlockingMainThread = true
+                    }
+                }
+            }
+
             if(it is KtCallExpression) {
                 val isUsingRunBlockingExpression = (it.calleeExpression as KtNameReferenceExpression).getReferencedNameAsName().identifier == RUN_BLOCKING_EXP_ID
                 if(isUsingRunBlockingExpression) {
@@ -63,6 +72,15 @@ class JerseyMainThreadBlockingCall(config: Config) : Rule(config)  {
                                methodBlockingMainThread = true
                            }
                        }
+                    }
+
+                    if(blkExp is KtDotQualifiedExpression) {
+                        blkExp.children.filterIsInstance<KtCallExpression>().map { c ->
+                            val isUsingRunBlockingExpression = (c.calleeExpression as KtNameReferenceExpression).getReferencedNameAsName().identifier == RUN_BLOCKING_EXP_ID
+                            if(isUsingRunBlockingExpression) {
+                                methodBlockingMainThread = true
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/ResourceApsecOnboarded.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/ResourceApsecOnboarded.kt
@@ -1,0 +1,54 @@
+package io.github.thewisenerd.linters.sidekt.rules
+
+import io.github.thewisenerd.linters.sidekt.helpers.Debugger
+import io.gitlab.arturbosch.detekt.api.*
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
+import org.jetbrains.kotlin.psi.*
+
+class ResourceApsecOnboarded(config: Config) : Rule(config) {
+
+    companion object {
+        val APSEC_ANNOTATION = arrayOf("UDErrorMonitoredApi")
+        val httpMethodList = arrayOf("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS")
+    }
+
+    private val debugStream by lazy {
+        valueOrNull<String>("debug")?.let {
+            Debugger.getOutputStreamForDebugger(it)
+        }
+    }
+
+    override val issue: Issue = Issue(
+        id = ResourceApsecOnboarded::class.java.simpleName,
+        severity = Severity.Performance,
+        description = "APSEC annotation is missed resource method",
+        debt = Debt.TEN_MINS
+    )
+
+
+    override fun visitNamedFunction(resourceMethod: KtNamedFunction) {
+        super.visitNamedFunction(resourceMethod)
+        val dbg = Debugger.make(ResourceApsecOnboarded::class.java.simpleName, debugStream)
+
+        val hasPathAnnotation = resourceMethod.hasAnnotation("Path")
+        val hasAnyOfHttpMethodAnnotation = resourceMethod.hasAnnotation(*httpMethodList)
+
+        if (!hasPathAnnotation && !hasAnyOfHttpMethodAnnotation) {
+            dbg.i("  hasPathAnnotation=false or none of http method annotation available")
+            return
+        }
+
+        var hasApsecAnnotation = resourceMethod.hasAnnotation(*APSEC_ANNOTATION)
+
+        if (hasApsecAnnotation.not()) {
+            dbg.i("APSEC annotation is missed for thread")
+            report(
+                CodeSmell(
+                    issue = issue,
+                    entity = Entity.from(resourceMethod),
+                    message = "Onboard Resources (${resourceMethod.name} on APSEC))"
+                )
+            )
+        }
+    }
+}

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/JerseyMainThreadBlockingCallTest.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/JerseyMainThreadBlockingCallTest.kt
@@ -1,0 +1,47 @@
+package io.github.thewisenerd.linters.sidekt
+
+import io.github.thewisenerd.linters.sidekt.rules.JerseyMainThreadBlockingCall
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.junit.Test
+
+class JerseyMainThreadBlockingCallTest {
+    companion object {
+        private val blockingJerseyMethod = JerseyMainThreadBlockingCall::class.java.simpleName
+
+        private fun ensureJerseyMethodParameterDefaultValueFindings(findings: List<Finding>, requiredFindings: List<SourceLocation>) =
+            TestUtils.ensureFindings(blockingJerseyMethod, findings, requiredFindings)
+    }
+
+    private val testConfig = object : Config {
+        override fun subConfig(key: String): Config = this
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any> valueOrNull(key: String): T? {
+            return when (key) {
+                "active" -> true as? T
+                "debug" -> "stderr" as? T
+                else -> null
+            }
+        }
+    }
+    private val subject = JerseyMainThreadBlockingCall(testConfig)
+
+
+    @Test
+    fun simple06() {
+        val code = TestUtils.readFile("simple06.kt")
+        val findings = subject.compileAndLintWithContext(TestUtils.env, code)
+        ensureJerseyMethodParameterDefaultValueFindings(findings, listOf(
+            SourceLocation(3, 5),
+            SourceLocation(8, 5),
+            SourceLocation(13, 5),
+            SourceLocation(18, 5),
+            SourceLocation(25, 5),
+            SourceLocation(42, 5)
+        ))
+    }
+
+}

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/JerseyMainThreadBlockingCallTest.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/JerseyMainThreadBlockingCallTest.kt
@@ -35,12 +35,13 @@ class JerseyMainThreadBlockingCallTest {
         val code = TestUtils.readFile("simple06.kt")
         val findings = subject.compileAndLintWithContext(TestUtils.env, code)
         ensureJerseyMethodParameterDefaultValueFindings(findings, listOf(
-            SourceLocation(3, 5),
-            SourceLocation(8, 5),
-            SourceLocation(13, 5),
-            SourceLocation(18, 5),
-            SourceLocation(25, 5),
-            SourceLocation(42, 5)
+            SourceLocation(4, 5),
+            SourceLocation(9, 5),
+            SourceLocation(14, 5),
+            SourceLocation(19, 5),
+            SourceLocation(26, 5),
+            SourceLocation(43, 5),
+            SourceLocation(48, 5)
         ))
     }
 

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/ResourceApsecOnboardedTest.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/ResourceApsecOnboardedTest.kt
@@ -1,0 +1,46 @@
+package io.github.thewisenerd.linters.sidekt
+import io.github.thewisenerd.linters.sidekt.rules.ResourceApsecOnboarded
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.junit.Test
+
+class ResourceApsecOnboardedTest {
+
+    companion object {
+        private val blockingJerseyMethod = ResourceApsecOnboarded::class.java.simpleName
+
+        private fun ensureJerseyMethodParameterDefaultValueFindings(
+            findings: List<Finding>,
+            requiredFindings: List<SourceLocation>
+        ) = TestUtils.ensureFindings(blockingJerseyMethod, findings, requiredFindings)
+    }
+
+    private val testConfig = object : Config {
+        override fun subConfig(key: String): Config = this
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any> valueOrNull(key: String): T? {
+            return when (key) {
+                "active" -> true as? T
+                "debug" -> "stderr" as? T
+                else -> null
+            }
+        }
+    }
+    private val subject = ResourceApsecOnboarded(testConfig)
+
+
+    @Test
+    fun testApsecResource() {
+        val code = TestUtils.readFile("TestApsecResource.kt")
+        val findings = subject.compileAndLintWithContext(TestUtils.env, code)
+        ensureJerseyMethodParameterDefaultValueFindings(
+            findings, listOf(
+                SourceLocation(14, 5),
+                SourceLocation(19, 5)
+            )
+        )
+    }
+}

--- a/src/test/resources/TestApsecResource.kt
+++ b/src/test/resources/TestApsecResource.kt
@@ -1,0 +1,31 @@
+import com.udaan.error.trace.annotations.Severity
+import com.udaan.error.trace.annotations.UDErrorMonitored
+import com.udaan.error.trace.annotations.UDErrorMonitoredApi
+
+@UDErrorMonitored("1")
+class TestApsecResource {
+
+    @Path("/variant01")
+    @UDErrorMonitoredApi("1", Severity.LOW, false)
+    fun testAPSECVariant01() {
+        "This is variation 01"
+    }
+
+    @Path("/variant02")
+    fun testAPSECVariant02(): String {
+        return "This is variation 02"
+    }
+
+    @GET
+    fun testAPSECVariant03() {
+        println("This is variation 03")
+    }
+
+    @GET
+    @UDErrorMonitoredApi("1", Severity.LOW, false)
+    fun testAPSECVariant08(): String {
+        println("This is variation 04")
+        return ""
+    }
+
+}

--- a/src/test/resources/simple06.kt
+++ b/src/test/resources/simple06.kt
@@ -1,0 +1,51 @@
+import kotlinx.coroutines.runBlocking
+
+    @Path("/variant01")
+    fun testRunBlockingVariant01() = runBlocking {
+            "This is variation 01"
+    }
+
+    @Path("/variant02")
+    fun testRunBlockingVariant02() : String = runBlocking{
+        "This is variation 02"
+    }
+
+    @Path("/variant03")
+    fun testRunBlockingVariant03()  = runBlocking{
+        return@runBlocking "This is variation 03"
+    }
+
+    @Path("/variant04")
+    fun testRunBlockingVariant04() : String {
+        return runBlocking{
+            return@runBlocking "This is variation 04"
+        }
+    }
+
+    @Path("/variant05")
+    fun testRunBlockingVariant05() : String {
+        println("This is variation 05")
+
+        runBlocking {
+            "This is variation 05"
+        }
+
+        return "This is variation 05"
+    }
+
+    @Path("/variant06")
+    fun testRunBlockingVariant06() : String {
+        println("This is variation 06")
+        return "This is variation 06"
+    }
+
+    @GET
+    fun testRunBlockingVariant07() = runBlocking {
+        println("This is variation 07")
+    }
+
+    @GET
+    fun testRunBlockingVariant08() : String {
+        println("This is variation 08")
+        return "This is variation 08"
+    }

--- a/src/test/resources/simple06.kt
+++ b/src/test/resources/simple06.kt
@@ -1,5 +1,6 @@
 import kotlinx.coroutines.runBlocking
 
+
     @Path("/variant01")
     fun testRunBlockingVariant01() = runBlocking {
             "This is variation 01"
@@ -47,5 +48,8 @@ import kotlinx.coroutines.runBlocking
     @GET
     fun testRunBlockingVariant08() : String {
         println("This is variation 08")
-        return "This is variation 08"
+        kotlinx.coroutines.runBlocking {
+            return@runBlocking "This is variation 08"
+        }
+        return ""
     }


### PR DESCRIPTION
The motive of the changes to find the newly added method without APSEC so that the repositories onboarded APSEC 100%.