### PR TITLE
BlockingCallContext: allow marking classes as blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ sidekt:
     ioDispatcherFqNames: ['com.custom.Dispatchers.DB']
     reclaimableMethodAnnotations: ['com.custom.annotations.ReclaimableBlockingCall']
     reclaimableMethodFqNames: ['com.custom.wrapper.getSync']
-
+    blockingClassAnnotations: ['com.custom.annotations.BlockingClass']
+    blockingClassFqNames: ['com.custom.dao.SomeDao']
 ```
 
 ### debug
@@ -86,6 +87,19 @@ already provide non-blocking method alternatives. such methods may be annotated 
 ### reclaimableMethodFqNames
 
 same as `reclaimableMethodAnnotations`, but allowing you to provide FQ names to the methods
+
+### blockingClassAnnotations
+
+these are the annotations which you may use in your code to denote blocking classes.
+
+similar to [blockingMethodAnnotations](#blockingMethodAnnotations), for classes.
+
+### blockingClassFqNames
+
+in case the annotations marking the class as blocking cannot be inferred (probably due to annotation retention at SOURCE), then,
+such known classes' FQ names can be configured.
+
+similar to [blockingMethodFqNames](#blockingMethodFqNames), for classes.
 
 ## JerseyMethodParameterDefaultValue
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ sidekt:
     reclaimableMethodFqNames: ['com.custom.wrapper.getSync']
     blockingClassAnnotations: ['com.custom.annotations.BlockingClass']
     blockingClassFqNames: ['com.custom.dao.SomeDao']
+
 ```
 
 ### debug

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/BlockingCallContext.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/BlockingCallContext.kt
@@ -234,7 +234,6 @@ class BlockingCallContext(config: Config) : Rule(config) {
         }
 
         // todo: figure out .extensionReceiverParameter
-        // todo: figure out superTypes annotations
         val classDescriptor = descriptor.dispatchReceiverParameter
         val classType = (classDescriptor?.containingDeclaration as? ClassDescriptor)
 
@@ -245,6 +244,7 @@ class BlockingCallContext(config: Config) : Rule(config) {
             return fromFqName(classFqName)
         }
 
+        // todo: figure out superTypes annotations, current impl only has classType annotations
         val classOrSuperTypesAnnotations = mutableListOf<AnnotationDescriptor>()
         classOrSuperTypesAnnotations += (classType?.annotations?.toList() ?: emptyList())
         classOrSuperTypesAnnotations.forEach { annotation ->

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/BlockingCallContextTest.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/BlockingCallContextTest.kt
@@ -32,8 +32,14 @@ class BlockingCallContextTest {
                 "blockingMethodAnnotations" -> arrayListOf(
                     "BlockingCall",
                     "RegularBlockingCall",
-                    "ReclaimableBlockingCall",
+                    "ReclaimableBlockingCall"
+                ) as? T
+
+                "blockingClassAnnotations" -> arrayListOf(
                     "BlockingClass"
+                ) as? T
+                "blockingClassFqNames" -> arrayListOf(
+                    "SomeRandomDao"
                 ) as? T
 
                 "blockingMethodFqNames" -> arrayListOf("Test03.foo", "kotlinx.coroutines.runBlocking") as? T
@@ -136,5 +142,14 @@ class BlockingCallContextTest {
                 SourceLocation(base01 + 21, 14)
             )
         )
+    }
+
+    @Test
+    fun simple07() {
+        val code = TestUtils.readFile("simple07.kt")
+        val findings = subject.compileAndLintWithContext(TestUtils.env, code)
+        ensureBlockingCallContextFindings(findings, listOf(
+            SourceLocation(11, 13)
+        ))
     }
 }

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/BlockingCallContextTest.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/BlockingCallContextTest.kt
@@ -14,7 +14,10 @@ class BlockingCallContextTest {
         private fun ensureBlockingCallContextFindings(findings: List<Finding>, requiredFindings: List<SourceLocation>) =
             TestUtils.ensureFindings(blockingCallContextClassName, findings, requiredFindings)
 
-        private fun ensureReclaimableBlockingCallContextFindings(findings: List<Finding>, requiredFindings: List<SourceLocation>) =
+        private fun ensureReclaimableBlockingCallContextFindings(
+            findings: List<Finding>,
+            requiredFindings: List<SourceLocation>
+        ) =
             TestUtils.ensureFindings("${blockingCallContextClassName}-Reclaimable", findings, requiredFindings)
     }
 
@@ -26,7 +29,13 @@ class BlockingCallContextTest {
             return when (key) {
                 "active" -> true as? T
                 "debug" -> "stderr" as? T
-                "blockingMethodAnnotations" -> arrayListOf("BlockingCall", "RegularBlockingCall", "ReclaimableBlockingCall") as? T
+                "blockingMethodAnnotations" -> arrayListOf(
+                    "BlockingCall",
+                    "RegularBlockingCall",
+                    "ReclaimableBlockingCall",
+                    "BlockingClass"
+                ) as? T
+
                 "blockingMethodFqNames" -> arrayListOf("Test03.foo", "kotlinx.coroutines.runBlocking") as? T
                 "reclaimableMethodAnnotations" -> arrayListOf("ReclaimableBlockingCall") as? T
                 "ioDispatcherFqNames" -> arrayListOf("CustomDispatchers.DB") as? T
@@ -92,6 +101,39 @@ class BlockingCallContextTest {
             findings, listOf(
                 SourceLocation(37, 22),
                 SourceLocation(43, 26)
+            )
+        )
+    }
+
+    @Test
+    fun simple06() {
+        val code = TestUtils.readFile("simple06.kt")
+        val base01 = 89
+        val findings = subject.compileAndLintWithContext(TestUtils.env, code)
+        ensureBlockingCallContextFindings(
+            findings, listOf(
+                SourceLocation(base01 + 0, 20),
+                // SourceLocation(base01+1, 20),
+                SourceLocation(base01 + 2, 20),
+                SourceLocation(base01 + 3, 20),
+
+                SourceLocation(base01 + 5, 14),
+                SourceLocation(base01 + 6, 14),
+                SourceLocation(base01 + 7, 14),
+                SourceLocation(base01 + 8, 14),
+
+                SourceLocation(base01 + 10, 20),
+                SourceLocation(base01 + 11, 20),
+                SourceLocation(base01 + 12, 20),
+
+                SourceLocation(base01 + 14, 26),
+
+                // SourceLocation(base01 + 16, 14)
+
+                SourceLocation(base01 + 18, 14),
+                // SourceLocation(base01 + 19, 14),
+                SourceLocation(base01 + 20, 14),
+                SourceLocation(base01 + 21, 14)
             )
         )
     }

--- a/src/test/resources/simple06.kt
+++ b/src/test/resources/simple06.kt
@@ -1,0 +1,112 @@
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class BlockingClass
+
+interface MyDao {
+    fun daoCall(): Int {
+        return 42
+    }
+}
+
+@BlockingClass
+interface MyInterface {
+    fun blockingInterfaceFunction(): Int {
+        return 42
+    }
+}
+
+@BlockingClass
+abstract class MyClass {
+    fun blockingClassFunction(): Int {
+        return 42
+    }
+
+    abstract fun dao(): MyDao
+}
+
+@BlockingClass
+object MyBlockingObject {
+    fun blockingObjectFunction(): Int {
+        return 42
+    }
+}
+
+fun MyClass.blockingExtensionFunction(): Int {
+    return 42
+}
+
+class Simple06(
+    private val interface1: MyInterface,
+    private val cls1: MyClass
+) {
+    @BlockingClass
+    open class MyNestedClass {
+        fun blockingNestedClassFunction(): Int {
+            return 42
+        }
+    }
+
+    private fun directReturnInterface(): MyInterface {
+        TODO()
+    }
+
+    private fun directReturnClass(): MyClass {
+        TODO()
+    }
+
+    private fun <T> inferredReturn(clazz: Class<T>): T {
+        TODO()
+    }
+
+    private fun directReturnNestedClass(): MyNestedClass {
+        TODO()
+    }
+
+    // interface
+    private val interface2 = object : MyInterface {
+        override fun blockingInterfaceFunction(): Int {
+            TODO()
+        }
+    }
+
+    private val interface3 = directReturnInterface()
+    private val interface4 = inferredReturn(MyInterface::class.java)
+
+    // class
+    private val cls2 = object : MyClass() {
+        override fun dao(): MyDao {
+            TODO()
+        }
+    }
+    private val cls3 = directReturnClass()
+    private val cls4 = inferredReturn(MyClass::class.java)
+
+    private val nestedCls2 = object : MyNestedClass() {}
+    private val nestedCls3 = directReturnNestedClass()
+    private val nestedCls4 = inferredReturn(MyNestedClass::class.java)
+
+    suspend fun test() {
+/*00*/  interface1.blockingInterfaceFunction()
+        // interface2.blockingInterfaceFunction() // this is not supported at the moment
+        interface3.blockingInterfaceFunction()
+        interface4.blockingInterfaceFunction()
+
+/*05*/  cls1.blockingClassFunction()
+        cls2.blockingClassFunction()
+        cls3.blockingClassFunction()
+        cls4.blockingClassFunction()
+
+/*10*/  nestedCls2.blockingNestedClassFunction()
+        nestedCls3.blockingNestedClassFunction()
+        nestedCls4.blockingNestedClassFunction()
+
+        MyBlockingObject.blockingObjectFunction()
+/*15*/
+        // cls1.blockingExtensionFunction()
+
+        cls1.dao().daoCall()
+        // cls2.dao().daoCall()
+/*20*/  cls3.dao().daoCall()
+        cls4.dao().daoCall()
+    }
+}

--- a/src/test/resources/simple06.kt
+++ b/src/test/resources/simple06.kt
@@ -1,4 +1,4 @@
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class BlockingClass
 

--- a/src/test/resources/simple07.kt
+++ b/src/test/resources/simple07.kt
@@ -1,0 +1,13 @@
+class SomeRandomDao {
+    fun daoCall(): Int {
+        return 42
+    }
+}
+
+class Simple07(
+    private val dao: SomeRandomDao
+) {
+    suspend fun test() {
+        dao.daoCall()
+    }
+}


### PR DESCRIPTION
note: all for the lack of a call graph (or whatever of), the knowledge which I do not possess, this won't help with transitive blocking calls (i.e., status-quo).

eg.,

```kotlin
@BlockingCall
fun blockingCall() { /* ... */ }

fun ignorantFunction() {
  // ...
  blockingCall()
  // ...
}

suspend fun plsDoNotRunBlockingCode() {
  ignorantFunction()
}
```